### PR TITLE
Use proxy obj

### DIFF
--- a/sample/test/flows/system.flow.create.js
+++ b/sample/test/flows/system.flow.create.js
@@ -14,7 +14,7 @@ describe('System flow: Create Account', () => {
   let testEnvironment, web3, toBN
 
   before('check "gsn-dock-relay" is active', async function () {
-    this.timeout(7000)
+    this.timeout(10000)
 
     testEnvironment = await TestEnvironment.initializeAndStartBackendForRealGSN({ verbose })
     await testEnvironment.snapshot()

--- a/solidity/contracts/PermissionsLevel.sol
+++ b/solidity/contracts/PermissionsLevel.sol
@@ -29,14 +29,14 @@ contract PermissionsLevel {
     uint32 constant public canSetAddOperatorNow = 1 << 14;
     uint32 constant public canAddOperatorNow = 1 << 15;
 
-    uint32 public canChangeConfig = canUnfreeze | canChangeParticipants | canAddOperator | canAddOperatorNow | canChangeBypass | canSetAcceleratedCalls | canSetAddOperatorNow/*| canChangeOwner*/ /* | canChangeDelays */;
-    uint32 public canCancel = canCancelSpend | canCancelConfigChanges | canCancelBypassCall;
+    uint32 constant public canChangeConfig = canUnfreeze | canChangeParticipants | canAddOperator | canAddOperatorNow | canChangeBypass | canSetAcceleratedCalls | canSetAddOperatorNow/*| canChangeOwner*/ /* | canChangeDelays */;
+    uint32 constant public canCancel = canCancelSpend | canCancelConfigChanges | canCancelBypassCall;
 
-    uint32 public ownerPermissions = canSpend | canCancel | canFreeze | canChangeConfig | canSignBoosts | canExecuteBypassCall;
-    uint32 public adminPermissions = /*canChangeOwner |*/ canExecuteBoosts | canAddOperator;
-    uint32 public watchdogPermissions = canCancel | canFreeze | canApprove;
+    uint32 constant public ownerPermissions = canSpend | canCancel | canFreeze | canChangeConfig | canSignBoosts | canExecuteBypassCall;
+    uint32 constant public adminPermissions = /*canChangeOwner |*/ canExecuteBoosts | canAddOperator;
+    uint32 constant public watchdogPermissions = canCancel | canFreeze | canApprove;
 
-    function comparePermissions(uint32 neededPermissions, uint32 senderPermissions) view internal {
+    function comparePermissions(uint32 neededPermissions, uint32 senderPermissions) pure internal {
         uint32 missingPermissions = neededPermissions & (senderPermissions ^ uint32(- 1));
         string memory error = Assert.concat("permissions missing: ", missingPermissions);
         require(missingPermissions == 0, error);

--- a/solidity/contracts/ProxyFactory.sol
+++ b/solidity/contracts/ProxyFactory.sol
@@ -1,0 +1,104 @@
+//from: https://gist.github.com/GNSPS/ba7b88565c947cfd781d44cf469c2ddb
+pragma solidity ^0.5.10;
+
+/* solhint-disable no-inline-assembly, indent, state-visibility, avoid-low-level-calls */
+
+contract ProxyFactory {
+    event ProxyDeployed(address proxyAddress, address targetAddress);
+    event ProxiesDeployed(address[] proxyAddresses, address targetAddress);
+
+    function createManyProxies(uint256 _count, address _target, bytes calldata _data)
+    external
+    {
+        address[] memory proxyAddresses = new address[](_count);
+
+        for (uint256 i = 0; i < _count; ++i) {
+            proxyAddresses[i] = createProxyImpl(_target, _data);
+        }
+
+        emit ProxiesDeployed(proxyAddresses, _target);
+    }
+
+    function createProxy(address _target, bytes calldata _data)
+    external
+    returns (address proxyContract)
+    {
+        proxyContract = createProxyImpl(_target, _data);
+
+        emit ProxyDeployed(proxyContract, _target);
+    }
+
+    function createProxyImpl(address _target, bytes memory _data)
+    internal
+    returns (address proxyContract)
+    {
+        assembly {
+            let contractCode := mload(0x40) // Find empty storage location using "free memory pointer"
+
+            mstore(add(contractCode, 0x0b), _target) // Add target address, with a 11 bytes [i.e. 23 - (32 - 20)] offset to later accomodate first part of the bytecode
+            mstore(sub(contractCode, 0x09), 0x000000000000000000603160008181600b9039f3600080808080368092803773) // First part of the bytecode, shifted left by 9 bytes, overwrites left padding of target address
+            mstore(add(contractCode, 0x2b), 0x5af43d828181803e808314602f57f35bfd000000000000000000000000000000) // Final part of bytecode, offset by 43 bytes
+
+            proxyContract := create(0, contractCode, 60) // total length 60 bytes
+            if iszero(extcodesize(proxyContract)) {
+                revert(0, 0)
+            }
+
+        // check if the _data.length > 0 and if it is forward it to the newly created contract
+            let dataLength := mload(_data)
+            if iszero(iszero(dataLength)) {
+                if iszero(call(gas, proxyContract, 0, add(_data, 0x20), dataLength, 0, 0)) {
+                    revert(0, 0)
+                }
+            }
+        }
+    }
+}
+
+/***
+*
+* PROXY contract (bytecode)
+
+603160008181600b9039f3600080808080368092803773f00df00df00df00df00df00df00df00df00df00d5af43d828181803e808314602f57f35bfd
+
+*
+* PROXY contract (opcodes)
+
+0 PUSH1 0x31
+2 PUSH1 0x00
+4 DUP2
+5 DUP2
+6 PUSH1 0x0b
+8 SWAP1
+9 CODECOPY
+10 RETURN
+11 PUSH1 0x00
+13 DUP1
+14 DUP1
+15 DUP1
+16 DUP1
+17 CALLDATASIZE
+18 DUP1
+19 SWAP3
+20 DUP1
+21 CALLDATACOPY
+22 PUSH20 0xf00df00df00df00df00df00df00df00df00df00d
+43 GAS
+44 DELEGATECALL
+45 RETURNDATASIZE
+46 DUP3
+47 DUP2
+48 DUP2
+49 DUP1
+50 RETURNDATACOPY
+51 DUP1
+52 DUP4
+53 EQ
+54 PUSH1 0x2f
+56 JUMPI
+57 RETURN
+58 JUMPDEST
+59 REVERT
+
+*
+***/

--- a/solidity/contracts/SmartAccount.sol
+++ b/solidity/contracts/SmartAccount.sol
@@ -94,12 +94,14 @@ contract SmartAccount is PermissionsLevel, GsnRecipient {
 
     address public creator;
 
-    constructor(address _forwarder, address _creator) public {
+    //constructor-method.must be called immediately after construction
+    // (or after proxy creation)
+    function ctr2(address _forwarder, address _creator) public {
+        require(creator==address(0), "ctr2: can only be called once");
         setGsnForwarder(_forwarder);
         deployedBlock = block.number;
         creator = _creator;
     }
-
 
     // ********** Access control modifiers below this point
 

--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -10,10 +10,11 @@ module.exports = async function (deployer) {
   await deployer.deploy(RelayHub)
   deployer.link(Utilities, Gatekeeper)
   const zeroAddress = '0x0000000000000000000000000000000000000000'
-  await deployer.deploy(SmartAccountFactory, zeroAddress, { gas: 9e6 })
+  await deployer.deploy(SmartAccountFactory, zeroAddress, { gas: 9e7 }).then(factory => factory.createAccountTemplate())
+
   // I think there is a bug in truffle, trying to deploy Gatekeeper first causes an error for no reason
   // console.log("Deploying Gatekeeper");
   // const gatekeeper =
-  await deployer.deploy(Gatekeeper, zeroAddress, zeroAddress, { gas: 8e6 })
+  await deployer.deploy(Gatekeeper, { gas: 8e6 })
   // console.log("Gatekeeper ", Gatekeeper.address);
 }

--- a/solidity/perm2js
+++ b/solidity/perm2js
@@ -15,14 +15,14 @@ while (<SRC>) {
         $switched=true;
     }
     #uint32 constant public canSpend = 1 << 0;
-    ($perm, $val) = /constant public (\w+)\s+=\s+(.*)\s*;\s*/;
+    ($perm, $val) = /constant public (\w+)\s+=\s+([^|]*)\s*;\s*/;
     if ($perm ) {
         push @perms, "\u$perm: $val";
         next;
     }
 
     #uint32 public canChangeConfig = canUnfreeze | canChangeParticipants /*| canChangeOwner*/ /* | canChan
-    ( $var ) = /uint32 public (.*=.*)\s*;\s*/;
+    ( $var ) = /public (.*=.*)\s*;\s*/;
     if ( $var ) {
         $var=~s/\s=/:/;
         $var=~s/\/\*.*?\*\/\s*//g;

--- a/solidity/src/js/FactoryContractInteractor.js
+++ b/solidity/src/js/FactoryContractInteractor.js
@@ -50,6 +50,7 @@ class FactoryContractInteractor {
     SmartAccountFactory.setProvider(provider)
     const instance = new FactoryContractInteractor(credentials, smartAccountFactoryAddress)
     instance.smartAccountFactory = await SmartAccountFactory.at(instance.smartAccountFactoryAddress)
+    instance.smartAccountFactory.createAccountTemplate()
     return instance
   }
 
@@ -151,8 +152,9 @@ class FactoryContractInteractor {
     const { instance } = await this.deployContract(
       'generated/SmartAccount',
       'SmartAccount',
-      [utilitiesContract], [zeroAddress(), from], from, ethNodeUrl
+      [utilitiesContract], [], from, ethNodeUrl
     )
+    await instance.ctr2(zeroAddress(), from, { from })
     return instance
   }
 
@@ -165,6 +167,7 @@ class FactoryContractInteractor {
     const utilitiesContract = await this.deployUtilitiesLibrary(from, ethNodeUrl)
     const { instance: smartAccountFactory } = await this.deployContract('generated/SmartAccountFactory',
       'SmartAccountFactory', [utilitiesContract], [forwarder], from, ethNodeUrl)
+    await smartAccountFactory.createAccountTemplate({ from })
     return smartAccountFactory
   }
 

--- a/solidity/test/TestProxyFactory.js
+++ b/solidity/test/TestProxyFactory.js
@@ -1,0 +1,26 @@
+/* global describe before it assert artifacts */
+const ProxyFactory = artifacts.require('ProxyFactory')
+const SmartAccount = artifacts.require('SmartAccount')
+
+describe('#ProxyFactory', () => {
+  let factory, template
+  before(async () => {
+    factory = await ProxyFactory.new()
+    template = await SmartAccount.new({ gas: 1e7 })
+  })
+
+  let acc
+
+  it('create proxy', async () => {
+    const ret = await factory.createProxy(template.address, '0x')
+    const proxyAddress = ret.logs.find(e => e.event === 'ProxyDeployed').args.proxyAddress
+
+    acc = await SmartAccount.at(proxyAddress)
+  })
+
+  it('modify proxy shouldn\'t change template', async () => {
+    await acc.ctr2('0x' + '0'.repeat(40), '0x' + '3'.repeat(40))
+    assert.equal(await acc.creator(), '0x' + '3'.repeat(40))
+    assert.equal(await template.creator(), '0x' + '0'.repeat(40))
+  })
+})

--- a/solidity/test/test_smart_account.js
+++ b/solidity/test/test_smart_account.js
@@ -172,7 +172,8 @@ contract('SmartAccount', async function (accounts) {
       SmartAccount.network.events[topic] = TestContract.events[topic]
     })
 
-    smartAccount = await SmartAccount.new(zeroAddress, accounts[0], { gas: 8e6 })
+    smartAccount = await SmartAccount.new({ gas: 8e6 })
+    await smartAccount.ctr2(zeroAddress, accounts[0])
     utilities = await Utilities.deployed()
     erc20 = await DAI.new()
     web3 = new Web3(smartAccount.contract.currentProvider)
@@ -953,7 +954,8 @@ contract('SmartAccount', async function (accounts) {
     let res
 
     before(async function () {
-      failCloseGK = await SmartAccount.new(zeroAddress, accounts[0], { gas: 8e6 })
+      failCloseGK = await SmartAccount.new({ gas: 8e6 })
+      await failCloseGK.ctr2(zeroAddress, accounts[0])
     })
 
     it('should initialize gk with failclose levels', async function () {

--- a/solidity/test/test_smart_account_bootstrapping.js
+++ b/solidity/test/test_smart_account_bootstrapping.js
@@ -60,6 +60,7 @@ contract('SmartAccount Bootstrapping', async function (accounts) {
       from, recipient, encodedFunctionCall, transactionFee,
       gasPrice, gasLimit, nonce, relayHub.address, relay)
     const signature = GsnUtils.getTransactionSignatureWithKey(ephemeralOperator.privateKey, hash)
+
     return relayHub.relayCall(
       from, recipient, encodedFunctionCall, transactionFee, gasPrice, gasLimit, nonce, signature, approvalData,
       {
@@ -74,7 +75,9 @@ contract('SmartAccount Bootstrapping', async function (accounts) {
     gsnSponsor = await FreeRecipientSponsor.new()
     gsnForwarder = await GsnForwarder.new(relayHub.address, gsnSponsor.address)
     await gsnSponsor.setForwarder(gsnForwarder.address)
-    smartAccountFactory = await SmartAccountFactory.new(gsnForwarder.address, { gas: 9e6, from: vfOwner })
+    smartAccountFactory = await SmartAccountFactory.new(gsnForwarder.address, { gas: 9e7, from: vfOwner })
+    await smartAccountFactory.createAccountTemplate({ from: vfOwner })
+
     whitelistFactory = await WhitelistFactory.new(gsnForwarder.address)
     ephemeralOperator = RelayClient.newEphemeralKeypair()
     await relayHub.stake(relay, 1231231, { from: accounts[2], value: 1e18 })

--- a/solidity/test/test_smart_account_factory.js
+++ b/solidity/test/test_smart_account_factory.js
@@ -21,7 +21,8 @@ contract('SmartAccountFactory', function (accounts) {
     smartAccountId = crypto.randomBytes(32)
     mockHub = await RelayHub.new({ gas: 9e6 })
     mockForwarder = await MockGsnForwarder.new(mockHub.address, { gas: 9e6 })
-    smartAccountFactory = await SmartAccountFactory.new(mockForwarder.address, { gas: 9e6, from: vfOwner })
+    smartAccountFactory = await SmartAccountFactory.new(mockForwarder.address, { gas: 9e7, from: vfOwner })
+    await smartAccountFactory.createAccountTemplate({ from: vfOwner })
     // Mocking backend signature
     const approvalData = await forgeApprovalData(smartAccountId, smartAccountFactory, vfOwner)
     callData = smartAccountFactory.contract.methods.newSmartAccount(smartAccountId, approvalData).encodeABI()

--- a/solidity/test/test_sponsor_gsn.js
+++ b/solidity/test/test_sponsor_gsn.js
@@ -35,7 +35,8 @@ contract('GSN and Sponsor integration', async function (accounts) {
   before(async function () {
     hub = await RelayHub.new()
     gsnForwarder = await MockGsnForwarder.new(hub.address)
-    gatekeeper = await Gatekeeper.new(gsnForwarder.address, accounts[0], { gas: 8e6 })
+    gatekeeper = await Gatekeeper.new({ gas: 8e6 })
+    await gatekeeper.ctr2(gsnForwarder.address, accounts[0])
     web3 = new Web3(gatekeeper.contract.currentProvider)
     ownerPermissions = utils.bufferToHex(await gatekeeper.ownerPermissions())
     operatorA = new Participant(accounts[0], ownerPermissions, 1, 'operatorA')


### PR DESCRIPTION
- SmartAccount constructor with empty params
- added `ctr2` for 2nd-level constructor. must be called immediately (same transaction) after constructor (or after proxy creation)
- ProxyFactory to create 60-bytes static proxy object

NOTE: did not optimize code yet, so not sure it already works without ganache relaxing params..